### PR TITLE
Show sidebar default with also taking mobile views in account

### DIFF
--- a/src/services/sidebarService.ts
+++ b/src/services/sidebarService.ts
@@ -1,5 +1,13 @@
 import { readonly, ref } from 'vue';
-export const showSideBar = ref(false);
+
+const getDefaultStatusSidebar = () => {
+    const width = document.documentElement.clientWidth;
+    if (width < 1024) return false;
+
+    return true;
+};
+
+export const showSideBar = ref(getDefaultStatusSidebar());
 
 export const getShowSideBar = () => readonly(showSideBar);
 export const toggleSideBar = () => {


### PR DESCRIPTION
Always show the sidebar, but if screen sizes are smaller than 1024px then we don't show it.
Because else you won't see the chat anymore.