### PR TITLE
Dev joris

### DIFF
--- a/apps/frontend/src/components/ChatInput.vue
+++ b/apps/frontend/src/components/ChatInput.vue
@@ -523,6 +523,10 @@
             case MessageTypes.FILE:
                 if (message.body.type === FileTypes.RECORDING) return 'Voice message';
                 return message.type;
+            case MessageTypes.EDIT:
+                const body = message.body as string | QuoteBodyType;
+                if (typeof body !== 'string') return body.message;
+                return body;
             default:
                 return message.type;
         }


### PR DESCRIPTION
#601 
Was missing a case for 'EDIT' which resulted in the default that just returns the message type ('EDIT') and not the message body. 