### PR TITLE
Dev joris

### DIFF
--- a/apps/backend/src/features/message/states/message.state.ts
+++ b/apps/backend/src/features/message/states/message.state.ts
@@ -7,6 +7,7 @@ import {
     GroupUpdate,
     IFileShareMessage,
     IPostShare,
+    MessageType,
     SystemMessage,
     SystemMessageType,
 } from '../../../types/message-types';
@@ -76,8 +77,9 @@ export class EditMessageState implements MessageState<string> {
     constructor(private readonly _chatGateway: ChatGateway, private readonly _messageService: MessageService) {}
 
     async handle({ message }: { message: MessageDTO<string> }) {
-        this._chatGateway.emitMessageToConnectedClients('message', message);
-        await this._messageService.editMessage({ messageId: message.id, text: message.body });
+        const editedMessage = await this._messageService.editMessage({ messageId: message.id, text: message.body });
+        editedMessage.type = MessageType.EDIT;
+        this._chatGateway.emitMessageToConnectedClients('message', editedMessage);
     }
 }
 

--- a/apps/frontend/src/components/ChatInput.vue
+++ b/apps/frontend/src/components/ChatInput.vue
@@ -392,6 +392,7 @@
 
         if (action.value) {
             const newMessage = createMessage();
+            //todo: if message has been edited, change the type back to string or quote before sending it back from server to client
             sendMessageObject(selectedId, newMessage);
             clearAction();
             clearMessage();

--- a/apps/frontend/src/components/ChatInput.vue
+++ b/apps/frontend/src/components/ChatInput.vue
@@ -221,7 +221,7 @@
     if (props.chat.draft) {
         if (props.chat.draft?.action === 'EDIT') {
             messageInput.value = String(props.chat.draft.body);
-            editMessage(props.chat.draft.to, props.chat.draft.body);
+            editMessage(props.chat.draft.to, props.chat.draft.body, props.chat.draft.id);
         }
         if (props.chat.draft?.action === 'REPLY') {
             messageInput.value = String(props.chat.draft.body.message);
@@ -392,7 +392,6 @@
 
         if (action.value) {
             const newMessage = createMessage();
-            //todo: if message has been edited, change the type back to string or quote before sending it back from server to client
             sendMessageObject(selectedId, newMessage);
             clearAction();
             clearMessage();

--- a/apps/frontend/src/components/Dashboard/Post.vue
+++ b/apps/frontend/src/components/Dashboard/Post.vue
@@ -159,7 +159,7 @@
             </div>
             <div class="mt-4 text-gray-600">
                 <!-- <p class="my-2 break-words">{{ item.post.body }}</p>-->
-                <div class="my-2 break-words">
+                <div class="my-2 break-words whitespace-pre-wrap">
                     <p v-if="!readMore && item.post.body.length > 200">
                         {{ item.post.body.slice(0, 200) }}
                     </p>

--- a/apps/frontend/src/components/MessageCard.vue
+++ b/apps/frontend/src/components/MessageCard.vue
@@ -38,7 +38,7 @@
                     <main class="max-w-[500px] break-all flex justify-between min-h-[36px]">
                         <MessageContent
                             :message="message"
-                            :key="String(message.id)"
+                            :key="String(message.id) + message.body"
                             :isDownloadingAttachment="isDownloadingAttachment"
                         ></MessageContent>
                     </main>

--- a/apps/frontend/src/components/MessageContentType/StringContent.vue
+++ b/apps/frontend/src/components/MessageContentType/StringContent.vue
@@ -29,7 +29,7 @@
 
     interface IProp {
         message: {
-            body: string | QuoteBodyType;
+            body: string | QuoteBodyType | number;
         };
     }
 
@@ -38,7 +38,8 @@
     const hyperlink = ref(null);
 
     let { body } = props.message;
-    if (typeof body !== 'string') body = body.message;
+    if (typeof body === 'object') body = body.message;
+    if (typeof body === 'number') body = body.toString();
 
     const replacer = (match: string) => emoji.emojify(match);
     const words = body.split(' ');

--- a/apps/frontend/src/store/chatStore.ts
+++ b/apps/frontend/src/store/chatStore.ts
@@ -90,7 +90,12 @@ const retrieveChats = async () => {
     });
 };
 
-export const editMessage = (chatId: string, message: any) => {
+export const editMessage = (chatId: string, message: any, messageId?: string) => {
+    if (messageId && typeof message === 'string') {
+        const chat = state.chats.find(c => c.chatId === chatId);
+        const msg = chat.messages.find(c => c.id === messageId);
+        message = { ...msg, body: message };
+    }
     clearMessageAction(chatId);
     //nextTick is needed because vue throws dom errors if you switch between Reply and Edit
     nextTick(() => {

--- a/apps/frontend/src/store/chatStore.ts
+++ b/apps/frontend/src/store/chatStore.ts
@@ -338,6 +338,7 @@ const addMessage = (chatId: string, message: any) => {
         const index = chat.messages.findIndex(mes => mes.id.toString() === message.id.toString());
 
         if (index === -1) return;
+        message.type = chat.messages[index].type;
         chat.messages[index] = message;
         return;
     }


### PR DESCRIPTION
#600 
- Message body can also be 'number' if the message only has numbers. Which gave an infinity loop and crashed the app, but is resolved with .toString()
- Editing messages changed the type to 'EDIT' until the page was refreshed. This resulted in several bugs.
- Because the type stayed the same the message didn't get reloaded by vue. So I changed the key so that when the body changes the key also gets updated and vue gets reloaded (best practice for re-render of Vue is with :key according to the docs) 
- Editing a reply message removed the 'quoted message' until the page was refreshed (now fixed)