### PR TITLE
Create group avatar

### DIFF
--- a/apps/frontend/src/components/Dashboard/Post.vue
+++ b/apps/frontend/src/components/Dashboard/Post.vue
@@ -83,6 +83,7 @@
                             >
                                 <AvatarImg
                                     :id="item.owner.id"
+                                    :contact="item.owner"
                                     :showOnlineStatus="false"
                                     class="w-12 h-12 rounded-full"
                                     alt="avatar"

--- a/apps/frontend/src/components/Dashboard/PostComment.vue
+++ b/apps/frontend/src/components/Dashboard/PostComment.vue
@@ -1,7 +1,13 @@
 <template>
     <div :class="{ 'ml-10': comment.type === CommentType.COMMENT_REPLY }" class="flex items-center space-x-2 relative">
         <VMenu placement="top">
-            <AvatarImg :id="comment.owner.id" :showOnlineStatus="false" :small="true" alt="avatar" />
+            <AvatarImg
+                :id="comment.owner.id"
+                :contact="comment.owner"
+                :showOnlineStatus="false"
+                :small="true"
+                alt="avatar"
+            />
 
             <template #popper>
                 <keep-alive>

--- a/apps/frontend/src/components/UserTableGroup.vue
+++ b/apps/frontend/src/components/UserTableGroup.vue
@@ -55,7 +55,7 @@
                                         </div>
                                         <div class="flex">
                                             <div class="flex-shrink-0 h-10 w-10">
-                                                <AvatarImg :id="item.id" alt="contact image" />
+                                                <AvatarImg :id="item.id" :contact="item" alt="contact image" />
                                             </div>
                                             <div class="ml-4">
                                                 <div class="text-sm font-medium text-gray-900">

--- a/apps/frontend/src/views/app/Conversation.vue
+++ b/apps/frontend/src/views/app/Conversation.vue
@@ -269,7 +269,7 @@
         </Alert>
 
         <Alert v-if="showDeleteDialog" :showAlert="showDeleteDialog" @close="showDeleteDialog = false">
-            <template #title> Deleting group</template>
+            <template #title>Deleting group</template>
             <template #content>
                 Do you really want to delete this group
                 <b>{{ chat?.name }}</b


### PR DESCRIPTION
can cancel PR #685 , included correct changes in this PR
- Now uses correct avatar for create group, post, comments. And not the default one if you delete the chat of the user