### PR TITLE
#719 improved file sharing with groups and multiple chats

### DIFF
--- a/apps/backend/src/features/api/api.service.ts
+++ b/apps/backend/src/features/api/api.service.ts
@@ -140,8 +140,8 @@ export class ApiService {
      * @param {string} obj.location - IPv6 location to send request to.
      * @param {string} obj.shareId - Share id to delete.
      */
-    async sendRemoveShare({ location, shareId }: { location: string; shareId: string }) {
-        const destinationUrl = `http://[${location}]/api/v2/quantum/share/${shareId}`;
+    async sendRemoveShare({ location, shareId, chatId }: { location: string; shareId: string; chatId: string }) {
+        const destinationUrl = `http://[${location}]/api/v2/quantum/share/${shareId}/${chatId}`;
         try {
             return await axios.delete(destinationUrl);
         } catch (error) {

--- a/apps/backend/src/features/quantum/quantum.controller.ts
+++ b/apps/backend/src/features/quantum/quantum.controller.ts
@@ -279,10 +279,10 @@ export class QuantumController {
         return (await this._quantumService.getShareById({ id }))?.toJSON();
     }
 
-    @Delete('share/:id')
-    async deleteShare(@Param('id') id: string) {
-        const share = await this._quantumService.getShareById({ id });
-        return await this._quantumService.handleIncomingDeleteShare({ share });
+    @Delete('share/:shareId/:chatId')
+    async deleteShare(@Param('shareId') shareId: string, @Param('chatId') chatId: string) {
+        const share = await this._quantumService.getShareById({ id: shareId });
+        return await this._quantumService.handleIncomingDeleteShare({ share, chatId });
     }
 
     @Get('share/path')

--- a/apps/frontend/src/components/fileBrowser/EditShare.vue
+++ b/apps/frontend/src/components/fileBrowser/EditShare.vue
@@ -26,9 +26,9 @@
                 <span v-else>Read</span>
             </div>
             <!-- <div class="cursor-pointer rounded-xl bg-gray-50 border border-gray-200 w-28 justify-between flex content-center items-center ">
-                <span @click="item.canWrite = false" class="p-2 rounded-xl" :class="{ 'bg-primary text-white': data.data.length <=1 }"> Read</span>
-                <span @click="item.canWrite = true" class="p-2 rounded-xl" :class="{ 'bg-primary text-white': data.data.length > 1}"> Write</span>
-            </div> -->
+<span @click="item.canWrite = false" class="p-2 rounded-xl" :class="{ 'bg-primary text-white': data.data.length <=1 }"> Read</span>
+<span @click="item.canWrite = true" class="p-2 rounded-xl" :class="{ 'bg-primary text-white': data.data.length > 1}"> Write</span>
+</div> -->
         </template>
         <template #data-delete="data">
             <span class="my-1 p-2 rounded-md bg-red-500 text-white cursor-pointer" @click="remove(data.row)">
@@ -124,11 +124,12 @@
     const remove = async (data: any) => {
         const chat = chats.value.find(c => c.chatId === data.userId);
         if (!chat) return;
-        const contact = chat.contacts.find(con => con.id === chat.chatId);
-        if ('location' in contact) {
-            await removeFilePermissions(data.userId, props.selectedFile.path, contact.location);
-            await renderPermissionsData();
-        }
+        let contact = chat.contacts.find(con => con.id === chat.chatId);
+        if (chat.isGroup) contact = chat.contacts.find(c => c.id === chat.adminId);
+        if (!contact) return;
+
+        await removeFilePermissions(data.userId, props.selectedFile.path, contact.location);
+        await renderPermissionsData();
     };
 </script>
 


### PR DESCRIPTION
- Made file sharing more stable for group chats / sharing with multiple chats
- Deleting shares deletes all file share messages of the share (previously only deleted 1 msg)
- Same when you delete a file
- Several bugs fixed for sharing the same file in group chat and other chat
- Tested several cases and seems to work fine